### PR TITLE
changes to make sure filters property is set

### DIFF
--- a/EntryArgs.php
+++ b/EntryArgs.php
@@ -26,7 +26,7 @@ class EntryArgs {
 	 */
 	public function setFilter($id, $operator, $value) {
 		$filter = new Filter($id, $operator, $value);
-		$filters[] = $filter->getFilterString();
+		array_push($this->filters, $filter);
 	}
 	
 	/**
@@ -37,7 +37,7 @@ class EntryArgs {
 	 */
 	public function getArgsAsQueryString() {
 		foreach ($this as $key => $value) {
-			if(is_array($key)) {
+			if($key == 'filters' && is_array($value)) {
 				$ret.= $this->getNumeredFilters().'&';
 			} else {
 				if ($value) $ret.= $key.'='.$value.'&';			
@@ -49,7 +49,7 @@ class EntryArgs {
 	private function getNumeredFilters() {
 		$count = 1;
 		foreach ($this->filters as $filter) {
-			$ret.='Filter'.$count.'='.$filter.'&';
+			$ret.='Filter'.$count.'='.$filter->getFilterString().'&';
 			$count++;
 		}
 		return rtrim($ret, '&');


### PR DESCRIPTION
It looks like `$this->filters` was never set in EntryArgs.php, so after setting filters the method `EntryArgs::getArgsAsQueryString()` gives the entire query string parameter without the filters. EntryArgs.php is modified here to make sure filters are in the query string.
