### PR TITLE
Fix for file upload not working

### DIFF
--- a/WufooValueObjects.php
+++ b/WufooValueObjects.php
@@ -211,7 +211,8 @@ class WufooSubmitField {
 	
 	public function getValue() {
 		if ($this->isFile) {
-			return "@$this->value";
+			$curl_file = curl_file_create($this->value, mime_content_type($this->value), pathinfo($this->value, PATHINFO_BASENAME));
+			return $curl_file;
 		} else {
 			return $this->value;
 		}

--- a/WufooValueObjects.php
+++ b/WufooValueObjects.php
@@ -211,8 +211,7 @@ class WufooSubmitField {
 	
 	public function getValue() {
 		if ($this->isFile) {
-			$curl_file = curl_file_create($this->value, mime_content_type($this->value), pathinfo($this->value, PATHINFO_BASENAME));
-			return $curl_file;
+			return curl_file_create($this->value, mime_content_type($this->value), pathinfo($this->value, PATHINFO_BASENAME));
 		} else {
 			return $this->value;
 		}


### PR DESCRIPTION
As described in issue #9, this fixes deprecated code preventing file fields being submitted to Wufoo correctly.
